### PR TITLE
Allow Schema subclasses to be returned from parse method

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -246,10 +246,10 @@ class Schema implements \JsonSerializable {
      * Parse a short schema and return the associated schema.
      *
      * @param array $arr The schema array.
-     * @return Schema Returns a new schema.
+     * @return static Returns a new schema.
      */
     public static function parse(array $arr) {
-        $schema = new Schema();
+        $schema = new static();
         $schema->schema = $schema->parseInternal($arr);
         return $schema;
     }

--- a/tests/Fixtures/ExtendedSchema.php
+++ b/tests/Fixtures/ExtendedSchema.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema\Tests\Fixtures;
+
+use Garden\Schema\Schema;
+
+/**
+ * A basic subclass of Schema.
+ */
+class ExtendedSchema extends Schema {
+}

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -8,6 +8,7 @@
 namespace Garden\Schema\Tests;
 
 use Garden\Schema\Schema;
+use Garden\Schema\Tests\Fixtures\ExtendedSchema;
 
 /**
  * Test schema parsing.
@@ -153,6 +154,14 @@ class ParseTest extends AbstractSchemaTest {
         ];
 
         $this->assertEquals($expected, $schema->jsonSerialize());
+    }
+
+    /**
+     * Verify the current class is returned from parse calls in Schema subclasses.
+     */
+    public function testSubclassing() {
+        $subclass = ExtendedSchema::parse([]);
+        $this->assertInstanceOf(ExtendedSchema::class, $subclass);
     }
 
     /**


### PR DESCRIPTION
Subclasses of `Schema` are only able to return `Schema` from their `parse` method calls. This update alters that method to use late static binding and return the actual class.