### PR TITLE
Add ability to pass constructor arguments with Schema::parse

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -246,10 +246,11 @@ class Schema implements \JsonSerializable {
      * Parse a short schema and return the associated schema.
      *
      * @param array $arr The schema array.
+     * @param mixed ...$args Constructor arguments for the schema instance.
      * @return static Returns a new schema.
      */
-    public static function parse(array $arr) {
-        $schema = new static();
+    public static function parse(array $arr, ...$args) {
+        $schema = new static([], ...$args);
         $schema->schema = $schema->parseInternal($arr);
         return $schema;
     }

--- a/tests/Fixtures/ExtendedSchema.php
+++ b/tests/Fixtures/ExtendedSchema.php
@@ -13,4 +13,29 @@ use Garden\Schema\Schema;
  * A basic subclass of Schema.
  */
 class ExtendedSchema extends Schema {
+
+    /** @var string */
+    public $controller;
+
+    /** @var string */
+    public $method;
+
+    /** @var string */
+    public $type;
+
+    /**
+     * ExtendedSchema constructor.
+     *
+     * @param array $schema
+     * @param string $controller
+     * @param string $method
+     * @param string $type
+     */
+    public function __construct(array $schema = [], $controller = null, $method = null, $type = null) {
+        parent::__construct($schema);
+
+        $this->controller = $controller;
+        $this->method = $method;
+        $this->type = $type;
+    }
 }

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -165,6 +165,16 @@ class ParseTest extends AbstractSchemaTest {
     }
 
     /**
+     * Test the ability to pass constructor arguments using the parse method.
+     */
+    public function testConstructorParameters() {
+        $subclass = ExtendedSchema::parse([], 'DiscussionController', 'index', 'out');
+        $this->assertEquals('DiscussionController', $subclass->controller);
+        $this->assertEquals('index', $subclass->method);
+        $this->assertEquals('out', $subclass->type);
+    }
+
+    /**
      * Test JSON schema format to type conversion (and back).
      *
      * @param array $arr The schema array.


### PR DESCRIPTION
The current implementation of `Schema::parse` does not allow passing constructor arguments to the instance it creates. This can be important for subclasses.

This update makes `Schema::parse` variadic and passes its `$args` parameter to the class's constructor.