### PR TITLE
Make the validation of empty values a bit more lax

### DIFF
--- a/tests/BasicSchemaTest.php
+++ b/tests/BasicSchemaTest.php
@@ -203,8 +203,8 @@ class BasicSchemaTest extends AbstractSchemaTest {
         $this->assertArrayNotHasKey('col', $missingData);
 
         $nullData = ['col' => null];
-        $isValid = $schema->isValid($nullData);
-        $this->assertFalse($isValid);
+        $valid = $schema->validate($nullData);
+        $this->assertSame([], $valid);
     }
 
     /**
@@ -478,5 +478,12 @@ class BasicSchemaTest extends AbstractSchemaTest {
 
         $valid = $schema->validate([], true);
         $this->assertSame([], $valid);
+    }
+
+    public function testBoolFalse() {
+        $schema = Schema::parse(['bool:b']);
+
+        $valid = $schema->validate(['bool' => false]);
+        $this->assertFalse($valid['bool']);
     }
 }

--- a/tests/RealWorldTest.php
+++ b/tests/RealWorldTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Garden\Schema\Tests;
+
+use Garden\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+
+class RealWorldTest extends TestCase {
+    /**
+     * An optional field should be stripped when provided with an empty string.
+     */
+    public function testEmptyOptional() {
+        $sch = Schema::parse(['a:i?']);
+
+        $valid = $sch->validate(['a' => '']);
+        $this->assertSame([], $valid);
+    }
+
+    /**
+     * An optional field should be stripped when provided with null.
+     */
+    public function testNullOptional() {
+        $sch = Schema::parse(['a:i?']);
+
+        $valid = $sch->validate(['a' => null]);
+        $this->assertSame([], $valid);
+    }
+
+    /**
+     * A nullable field should convert an empty string to null.
+     */
+    public function testEmptyNullable() {
+        $sch = Schema::parse(['a:i|n']);
+
+        $valid = $sch->validate(['a' => '']);
+        $this->assertSame(['a' => null], $valid);
+    }
+
+    /**
+     * A nullable optional field should convert various values to null.
+     */
+    public function testNullableOptional() {
+        $sch = Schema::parse(['a:i|n?']);
+
+        $valid = $sch->validate(['a' => '']);
+        $this->assertSame(['a' => null], $valid);
+
+        $valid = $sch->validate(['a' => null]);
+        $this->assertSame(['a' => null], $valid);
+    }
+
+    /**
+     * An optional string field should not strip empty strings.
+     */
+    public function testOptionalEmptyString() {
+        $sch = Schema::parse(['a:s?']);
+
+        $valid = $sch->validate(['a' => '']);
+        $this->assertSame(['a' => ''], $valid);
+    }
+}


### PR DESCRIPTION
Empty optional fields will now be stripped or set to null if allowed.