### PR TITLE
Upgrade Travis dist to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:


### PR DESCRIPTION
HHVM doesn't operate under Ubuntu Precise on Travis, any more. This kills the build. The options are to allow HHVM to fail or force the build to run under Ubuntu Trusty, which Travis will soon be using by default. Since this library runs fine under Trusty, I opted to go with the latter.