### PR TITLE
Return instances of objects when validating objects

### DIFF
--- a/tests/Fixtures/CustomArray.php
+++ b/tests/Fixtures/CustomArray.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema\Tests\Fixtures;
+
+
+use Traversable;
+
+class CustomArray implements \ArrayAccess, \IteratorAggregate {
+    private $arr = [];
+
+
+    /**
+     * Whether a offset exists
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @param mixed $offset <p>
+     * An offset to check for.
+     * </p>
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset) {
+        return isset($this->arr[$offset]);
+    }
+
+    /**
+     * Offset to retrieve
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @param mixed $offset <p>
+     * The offset to retrieve.
+     * </p>
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset) {
+        return $this->arr[$offset];
+    }
+
+    /**
+     * Offset to set
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @param mixed $offset <p>
+     * The offset to assign the value to.
+     * </p>
+     * @param mixed $value <p>
+     * The value to set.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value) {
+        if ($offset === null) {
+            $this->arr[] = $value;
+        } else {
+            $this->arr[$offset] = $value;
+        }
+    }
+
+    /**
+     * Offset to unset
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @param mixed $offset <p>
+     * The offset to unset.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset) {
+        unset($this->arr[$offset]);
+    }
+
+    public function getArrayCopy() {
+        return $this->arr;
+    }
+
+    /**
+     * Retrieve an external iterator
+     * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
+     * @return Traversable An instance of an object implementing <b>Iterator</b> or
+     * <b>Traversable</b>
+     * @since 5.0.0
+     */
+    public function getIterator() {
+        return new \ArrayIterator($this->arr);
+    }
+}

--- a/tests/Fixtures/CustomArrayObject.php
+++ b/tests/Fixtures/CustomArrayObject.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema\Tests\Fixtures;
+
+
+class CustomArrayObject extends \ArrayObject {
+
+}

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -364,13 +364,13 @@ class NestedSchemaTest extends AbstractSchemaTest {
 
         $valid = $schema->validate($data);
 
-        $expected = [
+        $expected = new \ArrayObject([
             'name' => 'bur',
             'arr' => [
-                ['id' => 1, 'foo' => 'bar'],
-                ['id' => 2, 'foo' => 'baz'],
+                new \ArrayObject(['id' => 1, 'foo' => 'bar']),
+                new \ArrayObject(['id' => 2, 'foo' => 'baz']),
             ]
-        ];
+        ]);
 
         $this->assertEquals($expected, $valid);
     }


### PR DESCRIPTION
When validating an ArrayObject or something similar then the valid data
should be an instance of the source class rather than an array.