### PR TITLE
Fix issues with requireOneOf

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -593,6 +593,11 @@ class Schema implements \JsonSerializable, \ArrayAccess {
         $result = $this->addValidator(
             $fieldname,
             function ($data, ValidationField $field) use ($required, $count) {
+                // This validator does not apply to sparse validation.
+                if ($field->isSparse()) {
+                    return true;
+                }
+
                 $hasCount = 0;
                 $flattened = [];
 
@@ -603,7 +608,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
                         // This is an array of required names. They all must match.
                         $hasCountInner = 0;
                         foreach ($name as $nameInner) {
-                            if (isset($data[$nameInner]) && $data[$nameInner]) {
+                            if (array_key_exists($nameInner, $data)) {
                                 $hasCountInner++;
                             } else {
                                 break;
@@ -612,7 +617,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
                         if ($hasCountInner >= count($name)) {
                             $hasCount++;
                         }
-                    } elseif (isset($data[$name]) && $data[$name]) {
+                    } elseif (array_key_exists($name, $data)) {
                         $hasCount++;
                     }
 

--- a/tests/BasicSchemaTest.php
+++ b/tests/BasicSchemaTest.php
@@ -302,6 +302,27 @@ class BasicSchemaTest extends AbstractSchemaTest {
     }
 
     /**
+     * Require one of on an empty array should fail.
+     *
+     * @expectedException \Garden\Schema\ValidationException
+     */
+    public function testRequireOneOfEmpty() {
+        $schema = Schema::parse(['a:i?', 'b:i?', 'c:i?'])->requireOneOf(['a', 'b', 'c'], '', 2);
+
+        $r = $schema->validate([]);
+    }
+
+    /**
+     * Require one of should not fire during sparse validation.
+     */
+    public function testRequireOneOfSparse() {
+        $schema = Schema::parse(['a:i?', 'b:i?', 'c:i?'])->requireOneOf(['a', 'b', 'c'], '', 2);
+
+        $r = $schema->validate([], true);
+        $r2 = $schema->validate(['a' => 1], true);
+    }
+
+    /**
      * Test a variety of invalid values.
      *
      * @param string $type The type short code.


### PR DESCRIPTION
- The requireOneOf validation should not fire during sparse validation.
- Switch requireOneOf to basic array_key_exists() calls. Fields that
are falsey are still present.