### PR TITLE
Properly merge schema-level errors for nested schemas

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -335,10 +335,11 @@ class Validation {
         foreach ($paths as $path => $errors) {
             foreach ($errors as $error) {
                 if (!empty($name)) {
-                    if (!empty($path)) {
-                        $fullPath = "{$name}.{$path}";
+                    // We are merging a sub-schema error that did not occur on a particular property of the sub-schema.
+                    if ($path === '') {
+                        $fullPath = "$name";
                     } else {
-                        $fullPath = $name;
+                        $fullPath = "{$name}.{$path}";
                     }
                     $this->addError($fullPath, $error['code'], $error);
                 }

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -335,7 +335,11 @@ class Validation {
         foreach ($paths as $path => $errors) {
             foreach ($errors as $error) {
                 if (!empty($name)) {
-                    $fullPath = "{$name}.{$path}";
+                    if (!empty($path)) {
+                        $fullPath = "{$name}.{$path}";
+                    } else {
+                        $fullPath = $name;
+                    }
                     $this->addError($fullPath, $error['code'], $error);
                 }
             }

--- a/tests/Fixtures/SchemaValidationFail.php
+++ b/tests/Fixtures/SchemaValidationFail.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema\Tests\Fixtures;
+
+use Garden\Schema\Schema;
+use Garden\Schema\ValidationField;
+use Garden\Schema\ValidationException;
+
+/**
+ * A Schema that throws a validation error from itself.
+ */
+class SchemaValidationFail extends Schema {
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($data, $sparse = false) {
+        $field = new ValidationField($this->createValidation(), $this->getSchemaArray(), '', $sparse);
+        $field->addError('invalid', ['messageCode' => '{field} is always invalid.']);
+        throw new ValidationException($field->getValidation());
+    }
+}

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -10,6 +10,7 @@ namespace Garden\Schema\Tests;
 use Garden\Schema\Schema;
 use Garden\Schema\ValidationException;
 use Garden\Schema\ValidationField;
+use Garden\Schema\Tests\Fixtures\SchemaValidationFail;
 
 /**
  * Tests for nested object schemas.
@@ -420,5 +421,17 @@ class NestedSchemaTest extends AbstractSchemaTest {
 
         $valid2 = $sch->validate($data);
         $this->assertEquals($data, $valid2);
+    }
+
+    /**
+     * Test that a schema that throws an exception in Schema::validate() will have a proper error message.
+     */
+    public function testNestedSchemaValidationFailureException() {
+        $schema = Schema::parse([
+            'sub-schema-fail' => new SchemaValidationFail()
+        ]);
+
+        $this->expectExceptionMessage('sub-schema-fail is always invalid.');
+        $schema->validate(['sub-schema-fail' => null]);
     }
 }


### PR DESCRIPTION
Fix an issue where error message would look like this:
`"message": "dateInserted. is not formatted as a valid date filter."`
instead of this
`"message": "dateInserted is not formatted as a valid date filter."`

After investigation I found out that this was caused by using a schema as a validator instead of doing validation on sub properties.
[Schemas base field object has no name](https://github.com/vanilla/garden-schema/blob/e342ac670084f8882390da278ad24c1385743f7c/src/Schema.php#L656).

 