### PR TITLE
Fix 1 appearing in field names of nested schema error messages

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -226,7 +226,7 @@ class Validation {
 
         // Massage the field name for better formatting.
         if (!$this->getTranslateFieldNames()) {
-            $field = (!empty($error['path']) ? ($error['path'][0] !== '[' ?: 'item').$error['path'].'.' : '').$error['field'];
+            $field = (!empty($error['path']) ? ($error['path'][0] !== '[' ? '' : 'item').$error['path'].'.' : '').$error['field'];
             $field = $field ?: (isset($error['index']) ? 'item' : 'value');
             if (isset($error['index'])) {
                 $field .= '['.$error['index'].']';

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -59,6 +59,25 @@ class NestedSchemaTest extends AbstractSchemaTest {
     }
 
     /**
+     * Verify field names in nested schema error messages appear as expected.
+     *
+     * @expectedException Garden\Schema\ValidationException
+     * @expectedExceptionMessage addr.zip is not a valid integer.
+     */
+    public function testNestedInvalidMessage() {
+        $sch = $this->getNestedSchema();
+        $result = $sch->validate([
+            'id' => 1,
+            'name' => 'Vanilla',
+            'addr' => [
+                'stree' => '123 Fake St.',
+                'city' => 'Nowhere',
+                'zip' => false
+            ]
+        ]);
+    }
+
+    /**
      * Test a variety of array item validation scenarios.
      */
     public function testArrayItemsType() {


### PR DESCRIPTION
`Validation::getErrorMessage` contains some code to massage field names. Part of the routine includes some string concatenation to format the field name. This concatenation includes the following:

```php
($error['path'][0] !== '[' ?: 'item')
```

If `$error['path']` does not start with a "[", then a "1" (the string representation of a boolean true) is inserted in the field name.

This update alters the ternary to include an empty string, instead of a "1", if `$error['path']` does not start with a "[".