### PR TITLE
Upgrade tests to be compatible with PHPUnit 6

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/phpunit.php"
         >
     <php>
         <ini name="intl.default_locale" value="en"/>

--- a/tests/AbstractSchemaTest.php
+++ b/tests/AbstractSchemaTest.php
@@ -7,13 +7,14 @@
 
 namespace Garden\Schema\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Garden\Schema\Schema;
 use Garden\Schema\Validation;
 
 /**
  * Base class for schema tests.
  */
-abstract class AbstractSchemaTest extends \PHPUnit_Framework_TestCase {
+abstract class AbstractSchemaTest extends TestCase {
     /**
      * Provides all of the schema types.
      *
@@ -143,6 +144,7 @@ abstract class AbstractSchemaTest extends \PHPUnit_Framework_TestCase {
         $codes = [];
         foreach ($validation->getFieldErrors($field) as $error) {
             if ($code === $error['code']) {
+                $this->assertEquals($code, $error['code']); // Need at least one assertion.
                 return;
             }
             $codes[] = $error['code'];

--- a/tests/BasicSchemaTest.php
+++ b/tests/BasicSchemaTest.php
@@ -196,7 +196,7 @@ class BasicSchemaTest extends AbstractSchemaTest {
      */
     public function testNotRequired($shortType) {
         if ($shortType === 'n') {
-            return;
+            $this->markTestSkipped();
         }
 
         $schema = Schema::parse([
@@ -222,7 +222,7 @@ class BasicSchemaTest extends AbstractSchemaTest {
     public function testRequiredEmpty($shortType) {
         // Bools and strings are special cases.
         if (in_array($shortType, ['b', 'n'])) {
-            return;
+            $this->markTestSkipped();
         }
 
         $schema = Schema::parse([
@@ -322,8 +322,13 @@ class BasicSchemaTest extends AbstractSchemaTest {
     public function testRequireOneOfSparse() {
         $schema = Schema::parse(['a:i?', 'b:i?', 'c:i?'])->requireOneOf(['a', 'b', 'c'], '', 2);
 
-        $r = $schema->validate([], true);
-        $r2 = $schema->validate(['a' => 1], true);
+        $data = [];
+        $result = $schema->validate($data, true);
+        $this->assertSame($data, $result);
+
+        $data2 = ['a' => 1];
+        $result2 = $schema->validate($data2, true);
+        $this->assertSame($data2, $result2);
     }
 
     /**

--- a/tests/OperationsTest.php
+++ b/tests/OperationsTest.php
@@ -159,10 +159,15 @@ class OperationsTest extends AbstractSchemaTest {
             'a:o' => ['b:s', 'c:i'],
             'b:a' => ['b:s', 'c:i']
         ]);
-
         $sch2 = $sch1->withSparse();
-        $sch2->validate([]);
-        $sch2->validate(['a' => ['c' => 1], 'b' => [['b' => 'foo']]]);
+
+        $data = [];
+        $result = $sch2->validate($data);
+        $this->assertSame($data, $result);
+
+        $data2 = ['a' => ['c' => 1], 'b' => [['b' => 'foo']]];
+        $result2 = $sch2->validate($data2);
+        $this->assertSame($data2, $result2);
     }
 
     /**

--- a/tests/PropertyTest.php
+++ b/tests/PropertyTest.php
@@ -7,12 +7,13 @@
 
 namespace Garden\Schema\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Garden\Schema\Schema;
 
 /**
  * Test property access of the schema object itself.
  */
-class PropertyTest extends \PHPUnit_Framework_TestCase {
+class PropertyTest extends TestCase {
     /**
      * Test basic property access.
      */

--- a/tests/StringValidationTest.php
+++ b/tests/StringValidationTest.php
@@ -32,6 +32,8 @@ class StringValidationTest extends AbstractSchemaTest {
 
             if (!empty($code)) {
                 $this->fail("'$str' shouldn't validate against a min length of $minLength.");
+            } else {
+                $this->assertGreaterThanOrEqual($minLength, strlen($str));
             }
         } catch (ValidationException $ex) {
             $this->assertFieldHasError($ex->getValidation(), 'str', $code);
@@ -73,6 +75,8 @@ class StringValidationTest extends AbstractSchemaTest {
 
             if (!empty($code)) {
                 $this->fail("'$str' shouldn't validate against a max length of $maxLength.");
+            } else {
+                $this->assertLessThanOrEqual($maxLength, strlen($str));
             }
         } catch (ValidationException $ex) {
             $this->assertFieldHasError($ex->getValidation(), 'str', $code);
@@ -111,6 +115,8 @@ class StringValidationTest extends AbstractSchemaTest {
 
             if (!empty($code)) {
                 $this->fail("'$str' shouldn't validate against a pattern of $pattern.");
+            } else {
+                $this->assertRegExp("/{$pattern}/", $str);
             }
         } catch (ValidationException $ex) {
             $this->assertFieldHasError($ex->getValidation(), 'str', $code);

--- a/tests/ValidationClassTest.php
+++ b/tests/ValidationClassTest.php
@@ -7,13 +7,14 @@
 
 namespace Garden\Schema\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Garden\Schema\Validation;
 use Garden\Schema\Tests\Fixtures\TestValidation;
 
 /**
  * Test the {@link Validation}.
  */
-class ValidationClassTest extends \PHPUnit_Framework_TestCase {
+class ValidationClassTest extends TestCase {
     /**
      * Adding an error to the validation object should make the object not valid.
      */

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -1,0 +1,7 @@
+<?php
+// PHPUnit v6 backwards compatibility with v5 error classes
+if (!class_exists('PHPUnit_Framework_Error_Notice') && class_exists('PHPUnit\\Framework\\Error\\Notice')) {
+    class_alias('PHPUnit\\Framework\\Error\\Notice', 'PHPUnit_Framework_Error_Notice');
+}
+
+require('vendor/autoload.php');


### PR DESCRIPTION
This update upgrades the suite of tests to be compatible with PHPUnit 6, without sacrificing compatibility with PHPUnit 5.

1. PHPUnit 5 is mostly foward-compatible with PHPUnit 6 classes, with the exception of `PHPUnit_Framework_Error_Notice` (and other error classes, not used here). A simple bootstrap has been added for tests and a class alias has been set for `PHPUnit_Framework_Error_Notice`.
1. In PHPUnit 6, all tests require at least one assertion. Assertions have been added, where necessary.
1. `markTestSkipped` is used in areas where testing is currently skipped with a return statement.