### PR TITLE
Remove redundant $sparse parameters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,3 +11,7 @@
 The following deprecations will throw deprecation notices, but still work in version 2, but will be removed in the next major version.
 
 - Schemas with multiple types are deprecated. The `nullable` property has been added to schemas to allow a type to also be null which should suit most purposes.
+
+### Backwards Incompatibility
+
+- Protected methods of the `Schema` class have changed signatures.


### PR DESCRIPTION
Since the ValidationField class has the sparse parameter in it we don’t need it in the protected methods.