### PR TITLE
Allow colons in properties passed to Schema::parse()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,11 @@
 
 ## Version 1 to Version 2
 
-With version 2, Garden Schema is moving away from JSON Schema and towards Open API. Since Open API is base on JSON Schema this isn't a major transition, but there are some differences. 
+With version 2, Garden Schema is moving away from JSON Schema and towards Open API. Since Open API is base on JSON Schema this isn't a major transition, but there are some differences.
+
+## Bug Fixes
+
+- Properties with colons in them no longer throw an invalid type exception. 
 
 ### New Features
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -539,13 +539,24 @@ class Schema implements \JsonSerializable, \ArrayAccess {
         }
 
         // Check for a type.
-        $parts = explode(':', $key);
-        $name = $parts[0];
+        if (false !== ($pos = strrpos($key, ':'))) {
+            $name = substr($key, 0, $pos);
+            $typeStr = substr($key, $pos + 1);
+
+            // Kludge for names with colons that are not specifying an array of a type.
+            if (isset($value['type']) && 'array' !== $this->getType($typeStr)) {
+                $name = $key;
+                $typeStr = '';
+            }
+        } else {
+            $name = $key;
+            $typeStr = '';
+        }
         $types = [];
         $param = [];
 
-        if (!empty($parts[1])) {
-            $shortTypes = explode('|', $parts[1]);
+        if (!empty($typeStr)) {
+            $shortTypes = explode('|', $typeStr);
             foreach ($shortTypes as $alias) {
                 $found = $this->getType($alias);
                 if ($found === null) {

--- a/tests/RealWorldTest.php
+++ b/tests/RealWorldTest.php
@@ -116,4 +116,44 @@ class RealWorldTest extends TestCase {
         $validatedData = $filteredSchema->validate($data);
         $this->assertEquals($expectedData, $validatedData);
     }
+
+    /**
+     * Colons should be allowed in property name short definitions.
+     */
+    public function testColonShortParse() {
+        $sch = Schema::parse([
+            'foo:bar:b',
+        ]);
+
+        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
+    }
+
+    /**
+     * Colons should be allowed in property name short definitions.
+     */
+    public function testColonLongParse() {
+        $sch = Schema::parse([
+            'foo:bar' => [
+                'type' => 'boolean',
+            ],
+        ]);
+
+        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
+    }
+
+    /**
+     * Colons should be allowed in full property name definitions.
+     */
+    public function testColonFullParse() {
+        $sch = Schema::parse([
+            'type' => 'object',
+            'properties' => [
+                'foo:bar' => [
+                    'type' => 'boolean',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
+    }
 }


### PR DESCRIPTION
Fixes #31