### PR TITLE
Backport additional numeric validation options to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ The **Schema** object is a wrapper for a [JSON Schema](http://json-schema.org/) 
 
 | Property | Type | Notes |
 | -------- | ---- | ----------- |
+| [multipleOf](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.1) | integer/number | A numeric instance is only valid if division by this keyword's value results in an integer. |
+| [maximum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.2) | integer/number |  If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum". |
+| [exclusiveMaximum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.3) | integer/number |  If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum". |
+| [minimum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4) | integer/number |  If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum". |
+| [exclusiveMinimum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.5) | integer/number |  If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum". |
 | [maxLength](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.6) | string | Limit the length of a string. |
 | [minLength](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.7) | string | Minimum length of a string. |
 | [pattern](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.8) | string | A regular expression without delimeters. |

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -862,6 +862,9 @@ class Schema implements \JsonSerializable, \ArrayAccess {
             $field->addTypeError('number');
             return Invalid::value();
         }
+
+        $result = $this->validateNumberProperties($result, $field);
+
         return $result;
     }
     /**
@@ -878,6 +881,9 @@ class Schema implements \JsonSerializable, \ArrayAccess {
             $field->addTypeError('integer');
             return Invalid::value();
         }
+
+        $result = $this->validateNumberProperties($result, $field);
+
         return $result;
     }
 
@@ -1575,5 +1581,52 @@ class Schema implements \JsonSerializable, \ArrayAccess {
         // Since we got here the value is invalid.
         $field->merge($typeValidation->getValidation());
         return Invalid::value();
+    }
+
+    /**
+     * Validate specific numeric validation properties.
+     *
+     * @param int|float $value The value to test.
+     * @param ValidationField $field Field information.
+     * @return int|float|Invalid Returns the number of invalid.
+     */
+    private function validateNumberProperties($value, ValidationField $field) {
+        $count = $field->getErrorCount();
+
+        if ($multipleOf = $field->val('multipleOf')) {
+            $divided = $value / $multipleOf;
+
+            if ($divided != round($divided)) {
+                $field->addError('multipleOf', ['messageCode' => '{field} is not a multiple of {multipleOf}.', 'status' => 422, 'multipleOf' => $multipleOf]);
+            }
+        }
+
+        if ($maximum = $field->val('maximum')) {
+            $exclusive = $field->val('exclusiveMaximum');
+
+            if ($value > $maximum || ($exclusive && $value == $maximum)) {
+                if ($exclusive) {
+                    $field->addError('maximum', ['messageCode' => '{field} is greater than or equal to {maximum}.', 'status' => 422, 'maximum' => $maximum]);
+                } else {
+                    $field->addError('maximum', ['messageCode' => '{field} is greater than {maximum}.', 'status' => 422, 'maximum' => $maximum]);
+                }
+
+            }
+        }
+
+        if ($minimum = $field->val('minimum')) {
+            $exclusive = $field->val('exclusiveMinimum');
+
+            if ($value < $minimum || ($exclusive && $value == $minimum)) {
+                if ($exclusive) {
+                    $field->addError('minimum', ['messageCode' => '{field} is greater than or equal to {minimum}.', 'status' => 422, 'minimum' => $minimum]);
+                } else {
+                    $field->addError('minimum', ['messageCode' => '{field} is greater than {minimum}.', 'status' => 422, 'minimum' => $minimum]);
+                }
+
+            }
+        }
+
+        return $field->getErrorCount() === $count ? $value : Invalid::value();
     }
 }

--- a/tests/NumericValidationTest.php
+++ b/tests/NumericValidationTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema\Tests;
+
+use Garden\Schema\Schema;
+use Garden\Schema\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+class NumericValidationTest extends TestCase {
+
+
+    /**
+     * Test multipleOf tests.
+     *
+     * @param int|float $value The value to test.
+     * @param int|float $multipleOf The multiple of property.
+     * @param bool $expected Whether or not the value should be valid.
+     * @dataProvider provideMultipleOfTests
+     */
+    public function testMultipleOf($value, $multipleOf, bool $expected) {
+        $sch = new Schema([
+            'type' => 'number',
+            'multipleOf' => $multipleOf
+        ]);
+
+        $valid = $sch->isValid($value);
+        $this->assertSame($expected, $valid);
+    }
+
+    /**
+     * Generate multipleOf tests.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideMultipleOfTests() {
+        $r = [
+            [1, 1, true],
+            [3, 2, false],
+            [5.5, 5, false],
+            [5.5, 1.1, true],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Test the maximum and exclusiveMaximum properties.
+     *
+     * @param int $max The maximum property.
+     * @param bool $exclusive The exclusiveMaximum property.
+     * @param bool $expected The expected valid result.
+     * @dataProvider provideMaximumTests
+     */
+    public function testMaximum($max, bool $exclusive, bool $expected) {
+        $sch = new Schema([
+            'type' => 'integer',
+            'maximum' => $max,
+            'exclusiveMaximum' => $exclusive,
+        ]);
+
+        try {
+            $sch->validate(5);
+            $this->assertTrue($expected);
+        } catch (ValidationException $ex) {
+            $this->assertFalse($expected);
+        }
+    }
+
+    /**
+     * Generate maximum property test data.
+     *
+     * @return mixed Returns a data provider array.
+     */
+    public function provideMaximumTests() {
+        $r = [
+            [5, false, true],
+            [4, false, false],
+            [5, true, false],
+            [6, true, true],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Test the minimum and exclusiveMinimum properties.
+     *
+     * @param int $min The minimum property.
+     * @param bool $exclusive The exclusiveMinimum property.
+     * @param bool $expected The expected valid result.
+     * @dataProvider provideMinimumTests
+     */
+    public function testMinimum($min, bool $exclusive, bool $expected) {
+        $sch = new Schema([
+            'type' => 'integer',
+            'minimum' => $min,
+            'exclusiveMinimum' => $exclusive,
+        ]);
+
+        try {
+            $sch->validate(5);
+            $this->assertTrue($expected);
+        } catch (ValidationException $ex) {
+            $this->assertFalse($expected);
+        }
+    }
+
+    /**
+     * Generate minimum property test data.
+     *
+     * @return mixed Returns a data provider array.
+     */
+    public function provideMinimumTests() {
+        $r = [
+            [5, false, true],
+            [6, false, false],
+            [5, true, false],
+            [4, true, true],
+        ];
+
+        return $r;
+    }
+}


### PR DESCRIPTION
Garden Schema v2 has some excellent numeric validation. It would be fantastic to get those in v1. That is the intention of this PR: backport 33c254d03972daf3ab06eb057b1f8ef8a8b75fb6 to a v1.9 release branch.