### PR TITLE
OpenAPI v3 allof support

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1467,12 +1467,17 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      *
      * @param ValidationField $field The validation results to add.
      * @return array Returns an array of merged specs.
+     * @throws ParseException Throws an exception if an invalid allof member is provided
      * @throws RefNotFoundException Throws an exception if the array has an items `$ref` that cannot be found.
      */
     protected function resolveAllOfTree(ValidationField $field) {
         $result = [];
 
         foreach($field->getAllOf() as $allof) {
+            if (!is_array($allof) || empty($allof)) {
+                throw new ParseException("Invalid allof member in {$field->getSchemaPath()}, array expected", 500);
+            }
+
             list ($items, $schemaPath) = $this->lookupSchema($allof, $field->getSchemaPath());
 
             $allOfValidation = new ValidationField(

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1372,7 +1372,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
                 $field->addError(
                     'pattern',
                     [
-                        'messageCode' => $field->val('x-patternMessageCode', 'The value doesn\'t match the required pattern '.$regex.'.'),
+                        'messageCode' => $field->val('x-patternMessageCode', 'The value doesn\'t match the required pattern.'),
                     ]
                 );
             }
@@ -1470,7 +1470,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @throws ParseException Throws an exception if an invalid allof member is provided
      * @throws RefNotFoundException Throws an exception if the array has an items `$ref` that cannot be found.
      */
-    protected function resolveAllOfTree(ValidationField $field) {
+    private function resolveAllOfTree(ValidationField $field) {
         $result = [];
 
         foreach($field->getAllOf() as $allof) {
@@ -1506,7 +1506,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @return array|Invalid Returns an array or invalid if validation fails.
      * @throws RefNotFoundException Throws an exception if the array has an items `$ref` that cannot be found.
      */
-    protected function validateAllOf($value, ValidationField $field) {
+    private function validateAllOf($value, ValidationField $field) {
         $allOfValidation = new ValidationField(
             $field->getValidation(),
             $this->resolveAllOfTree($field),

--- a/src/ValidationField.php
+++ b/src/ValidationField.php
@@ -167,6 +167,24 @@ class ValidationField {
     }
 
     /**
+     * Check if allOf is available
+     *
+     * @return bool
+     */
+    public function hasAllOf() {
+        return isset($this->field['allOf']);
+    }
+
+    /**
+     * Get allof tree
+     *
+     * @return array
+     */
+    public function getAllOf() {
+        return $this->field['allOf'] ?? [];
+    }
+
+    /**
      * Get the field type.
      *
      * @return string|string[] Returns a type string, array of type strings, or null if there isn't one.

--- a/tests/AllOfTest.php
+++ b/tests/AllOfTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema\Tests;
+
+use Garden\Schema\ArrayRefLookup;
+use Garden\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests allOf
+ */
+class AllOfTest extends TestCase {
+
+    /**
+     * @var ArrayRefLookup
+     */
+    private $lookup;
+
+    public function setUp() {
+        parent::setUp();
+
+        $arr = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => [
+                                'type' => 'string',
+                            ]
+                        ]
+                    ],
+                    'Cat' => [
+                        'allOf' => [
+                            ['$ref' => '#/components/schemas/Pet'],
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'likes' => [
+                                        'type' => 'string',
+                                        'enum' => ['milk', 'purring'],
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'Dog' => [
+                        'allOf' => [
+                            ['$ref' => '#/components/schemas/Pet'],
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'isGoodBoy' => [
+                                        'type' => 'boolean',
+                                        'default' => true,
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'Puppy' => [
+                        'allOf' => [
+                            ['$ref' => '#/components/schemas/Dog'],
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'canRun' => [
+                                        'type' => 'boolean',
+                                        'default' => false,
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'Invalid1' => [
+                        'allOf' => [
+                            ['$ref' => '#/components/schemas/Dog'],
+                            1,
+                        ]
+                    ],
+                ]
+            ]
+        ];
+
+        $this->lookup = new ArrayRefLookup($arr);
+    }
+
+    /**
+     * Test allof with two elements
+     */
+    public function testResolveOneLevel() {
+        $schema = new Schema(['$ref' => '#/components/schemas/Cat'], $this->lookup);
+        $valid = $schema->validate(['name' => 'mauzi', 'likes' => 'milk']);
+        $this->assertSame(['name' => 'mauzi', 'likes' => 'milk'], $valid);
+    }
+
+    /**
+     * Test allof with two elements while one of those has another allof
+     */
+    public function testResolveTwoLevel() {
+        $schema = new Schema(['$ref' => '#/components/schemas/Puppy'], $this->lookup);
+        $valid = $schema->validate(['name' => 'roger', 'isGoodBoy' => true, 'canRun' => false]);
+        $this->assertSame(['name' => 'roger', 'isGoodBoy' => true, 'canRun' => false], $valid);
+    }
+
+    /**
+     * Fail if an invalid value is provided
+     *
+     * @expectedException \Garden\Schema\ValidationException
+     * @expectedExceptionMessageRegExp `Unexpected property: notExists.`
+     */
+    public function testInvalidProperty() {
+        $schema = new Schema(['$ref' => '#/components/schemas/Puppy'], $this->lookup);
+        $schema->setFlags(Schema::VALIDATE_EXTRA_PROPERTY_EXCEPTION);
+        $schema->validate(['name' => 'roger', 'isGoodBoy' => true, 'notExists' => true]);
+    }
+
+    /**
+     * Allof members must be array
+     *
+     * @expectedException \Garden\Schema\ParseException
+     */
+    public function testInvalidAllOf() {
+        $schema = new Schema(['$ref' => '#/components/schemas/Invalid1'], $this->lookup);
+        $valid = $schema->validate(['type' => 'Invalid1']);
+    }
+}


### PR DESCRIPTION
This pr provides the possibility to implement `allOf` declarations according to specs.
See https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof

