### PR TITLE
Backport removal of deprecated FILTER_VALIDATE_URL flags

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1070,7 +1070,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
                     break;
                 case 'uri':
                     $type = 'URI';
-                    $result = filter_var($result, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED | FILTER_FLAG_SCHEME_REQUIRED);
+                    $result = filter_var($result, FILTER_VALIDATE_URL);
                     break;
                 default:
                     trigger_error("Unrecognized format '$format'.", E_USER_NOTICE);


### PR DESCRIPTION
PHP 7.3 officially deprecates the `FILTER_FLAG_SCHEME_REQUIRED and `FILTER_FLAG_HOST_REQUIRED` flags of `FILTER_VALIDATE_URL` in `filter_var`. These flags have been [removed from the latest version of garden-schema](https://github.com/vanilla/garden-schema/blob/17da87a83d15d45cfedc4d27cf800618160e1cbf/src/Schema.php#L1407). This update backports that change to remove these deprecated flags.