### PR TITLE
[Backport 1.x] Add ability to validate max byte length - VNLA-500, VNL-465

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,31 @@ The Garden Schema is a simple data validation and cleaning library based on [JSO
 
 ## Features
 
-- Define the data structures of PHP arrays of any depth, and validate them.
+-   Define the data structures of PHP arrays of any depth, and validate them.
 
-- Validated data is cleaned and coerced into appropriate types.
+-   Validated data is cleaned and coerced into appropriate types.
 
-- The schema defines a whitelist of allowed data and strips out all extraneous data.
+-   The schema defines a whitelist of allowed data and strips out all extraneous data.
 
-- The **Schema** class understands data in [JSON Schema](http://json-schema.org/) format. We will add more support for the built-in JSON schema validation as time goes on.
+-   The **Schema** class understands data in [JSON Schema](http://json-schema.org/) format. We will add more support for the built-in JSON schema validation as time goes on.
 
-- Developers can use a shorter schema format in order to define schemas in code rapidly. We built this class to be as easy to use as possible. Avoid developer groans as they lock down their data.
+-   Developers can use a shorter schema format in order to define schemas in code rapidly. We built this class to be as easy to use as possible. Avoid developer groans as they lock down their data.
 
-- Add custom validator callbacks to support practically any validation scenario.
+-   Add custom validator callbacks to support practically any validation scenario.
 
-- Override the validation class in order to customize the way errors are displayed for your own application.
+-   Override the validation class in order to customize the way errors are displayed for your own application.
 
 ## Uses
 
 Garden Schema is meant to be a generic wrapper for data validation. It should be valuable when you want to bullet-proof your code against user-submitted data. Here are some example uses:
 
-- Check the data being submitted to your API endpoints. Define the schema at the beginning of your endpoint and validate the data before doing anything else. In this way you can be sure that you are using clean data and avoid a bunch of spaghetti checks later in your code. This was the original reason why we developed the Garden Schema.
+-   Check the data being submitted to your API endpoints. Define the schema at the beginning of your endpoint and validate the data before doing anything else. In this way you can be sure that you are using clean data and avoid a bunch of spaghetti checks later in your code. This was the original reason why we developed the Garden Schema.
 
-- Clean user input. The Schema object will cast data to appropriate types and gracefully handle common use-cases (ex. converting the string "true" to true for booleans). This allows you to use more "===" checks in your code which helps avoid bugs in the longer term.
+-   Clean user input. The Schema object will cast data to appropriate types and gracefully handle common use-cases (ex. converting the string "true" to true for booleans). This allows you to use more "===" checks in your code which helps avoid bugs in the longer term.
 
-- Validate data before passing it to the database in order to present human-readable errors rather than cryptic database generated errors.
+-   Validate data before passing it to the database in order to present human-readable errors rather than cryptic database generated errors.
 
-- Clean output before returning it. A lot of database drivers return data as strings even though it's defined as different types. The Schema will clean the data appropriately which is especially important for consumption by the non-PHP world.
+-   Clean output before returning it. A lot of database drivers return data as strings even though it's defined as different types. The Schema will clean the data appropriately which is especially important for consumption by the non-PHP world.
 
 ## Basic Usage
 
@@ -78,7 +78,7 @@ By default the schema is an array where each element of the array defines an obj
         ...
     ]
 ]
- ```
+```
 
 You can quickly define an object schema by giving just as much information as you need. You can create a schema that is nested as deeply as you want in order to validate very complex data. This short schema is converted into a JSON schema compatible array internally and you can see this array with the **jsonSerialize()** method.
 
@@ -88,16 +88,16 @@ We provide first-class support for descriptions because we believe in writing re
 
 The **Schema** class supports the following types. Each type has a short-form and a long-form. Usually you use the short-form when defining a schema in code and it gets converted to the long-form internally, including when used in errors.
 
-Type      | Short-form
---------- | ----------
-boolean   | b, bool
-string    | s, str
-integer   | i, int
-number    | f, float
-timestamp | ts
-datetime  | dt
-array     | a
-object    | o
+| Type      | Short-form |
+| --------- | ---------- |
+| boolean   | b, bool    |
+| string    | s, str     |
+| integer   | i, int     |
+| number    | f, float   |
+| timestamp | ts         |
+| datetime  | dt         |
+| array     | a          |
+| object    | o          |
 
 ### Arrays and Objects
 
@@ -211,6 +211,44 @@ Both **validate()** and **isValid()** can take an additional **$sparse** paramet
 
 When you do a sparse validation, missing properties do not give errors and the sparse data is returned. Sparse validation allows you to use the same schema for inserting vs. updating records. This is common in databases or APIs with POST vs. PATCH requests.
 
+## Flags
+
+Flags can be applied a schema to change it's inherit validation.
+
+```php
+use Garden\Schema\Schema;
+$schema = Schema::parse([]);
+
+// Enable a flag.
+$schema->setFlag(Schema::VALIDATE_STRING_LENGTH_AS_UNICODE, true);
+
+// Disable a flag.
+$schema->setFlag(Schema::VALIDATE_STRING_LENGTH_AS_UNICODE, false);
+
+// Set all flags together.
+$schema->setFlags(Schema::VALIDATE_STRING_LENGTH_AS_UNICODE & Schema::VALIDATE_EXTRA_PROPERTY_NOTICE);
+
+// Check if a flag is set.
+$schema->hasFlag(Schema::VALIDATE_STRING_LENGTH_AS_UNICODE); // true
+```
+
+### `VALIDATE_STRING_LENGTH_AS_UNICODE`
+
+By default, schema's validate str lengths in terms of bytes. This is useful because this is the common
+unit of storage for things like databases.
+
+Some unicode characters take more than 1 byte. An emoji like 😱 takes 4 bytes for example.
+
+Enable this flag to validate unicode character length instead of byte length.
+
+### `VALIDATE_EXTRA_PROPERTY_NOTICE`
+
+Set this flag to trigger notices whenever a validated object has properties not defined in the schema.
+
+### `VALIDATE_EXTRA_PROPERTY_EXCEPTION`
+
+Set this flag to throw an exception whenever a validated object has properties not defined in the schema.
+
 ## Overriding the Validation Class and Localization
 
 Since schemas generate error messages, localization may be an issue. Although the Garden Schema doesn't offer any localization capabilities itself, it is designed to be extended in order to add localization yourself. You do this by subclassing the **Validation** class and overriding its **translate()** method. Here is a basic example:
@@ -234,30 +272,30 @@ $schema->setValidationClass(LocalizedValidation::class);
 
 There are a few things to note in the above example:
 
-- When overriding **translate()** be sure to handle the case where a string starts with the '@' character. Such strings should not be translated and have the character removed.
+-   When overriding **translate()** be sure to handle the case where a string starts with the '@' character. Such strings should not be translated and have the character removed.
 
-- You tell a **Schema** object to use your specific **Validation** subclass with the **setValidationClass()**. This method takes either a class name or an object instance. If you pass an object it will be cloned every time a validation object is needed. This is good when you want to use dependency injection and your class needs more sophisticated instantiation.
+-   You tell a **Schema** object to use your specific **Validation** subclass with the **setValidationClass()**. This method takes either a class name or an object instance. If you pass an object it will be cloned every time a validation object is needed. This is good when you want to use dependency injection and your class needs more sophisticated instantiation.
 
 ## JSON Schema Support
 
 The **Schema** object is a wrapper for a [JSON Schema](http://json-schema.org/) array. This means that you can pass a valid JSON schema to Schema's constructor. The table below lists the JSON Schema properties that are supported.
 
-| Property | Type | Notes |
-| -------- | ---- | ----------- |
-| [multipleOf](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.1) | integer/number | A numeric instance is only valid if division by this keyword's value results in an integer. |
-| [maximum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.2) | integer/number |  If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum". |
-| [exclusiveMaximum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.3) | integer/number |  If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum". |
-| [minimum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4) | integer/number |  If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum". |
-| [exclusiveMinimum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.5) | integer/number |  If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum". |
-| [maxLength](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.6) | string | Limit the unicode character length of a string. |
-| [minLength](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.7) | string | Minimum length of a string. |
-| [pattern](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.8) | string | A regular expression without delimeters. |
-| [items](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.9) | array | Ony supports a single schema. |
-| [maxItems](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.11) | array | Limit the number of items in an array. |
-| [minItems](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.12) | array | Minimum number of items in an array. |
-| [required](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.17) | object | Names of required object properties. |
-| [properties](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.18) | object | Specify schemas for object properties. |
-| [enum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.23) | any | Specify an array of valid values. |
-| [type](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25) | any | Specify a type of an array of types to validate a value. |
-| [default](http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3) | object | Applies to a schema that is in an object property. |
-| [format](http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3) | string | Support for date-time, email, ipv4, ipv6, ip, uri. |
+| Property                                                                                        | Type           | Notes                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [multipleOf](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.1)       | integer/number | A numeric instance is only valid if division by this keyword's value results in an integer.                                             |
+| [maximum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.2)          | integer/number | If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "maximum".               |
+| [exclusiveMaximum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.3) | integer/number | If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".    |
+| [minimum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.4)          | integer/number | If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "minimum".            |
+| [exclusiveMinimum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.5) | integer/number | If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum". |
+| [maxLength](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.6)          | string         | Limit the unicode character length of a string.                                                                                         |
+| [minLength](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.7)          | string         | Minimum length of a string.                                                                                                             |
+| [pattern](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.8)            | string         | A regular expression without delimeters.                                                                                                |
+| [items](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.9)              | array          | Ony supports a single schema.                                                                                                           |
+| [maxItems](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.11)          | array          | Limit the number of items in an array.                                                                                                  |
+| [minItems](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.12)          | array          | Minimum number of items in an array.                                                                                                    |
+| [required](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.17)          | object         | Names of required object properties.                                                                                                    |
+| [properties](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.18)        | object         | Specify schemas for object properties.                                                                                                  |
+| [enum](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.23)              | any            | Specify an array of valid values.                                                                                                       |
+| [type](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25)              | any            | Specify a type of an array of types to validate a value.                                                                                |
+| [default](http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3)            | object         | Applies to a schema that is in an object property.                                                                                      |
+| [format](http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3)             | string         | Support for date-time, email, ipv4, ipv6, ip, uri.                                                                                      |

--- a/tests/StringValidationTest.php
+++ b/tests/StringValidationTest.php
@@ -22,10 +22,15 @@ class StringValidationTest extends AbstractSchemaTest {
      * @param string $str The string to test.
      * @param string $code The expected error code, if any.
      * @param int $minLength The min length to test.
+     * @param int $flags Flags to set on the schema.
+     *
      * @dataProvider provideMinLengthTests
      */
-    public function testMinLength($str, $code, $minLength = 3) {
+    public function testMinLength($str, $code, $minLength = 3, int $flags = null) {
         $schema = Schema::parse(['str:s' => ['minLength' => $minLength]]);
+        if ($flags) {
+            $schema->setFlags($flags);
+        }
 
         try {
             $schema->validate(['str' => $str]);
@@ -33,7 +38,8 @@ class StringValidationTest extends AbstractSchemaTest {
             if (!empty($code)) {
                 $this->fail("'$str' shouldn't validate against a min length of $minLength.");
             } else {
-                $this->assertGreaterThanOrEqual($minLength, strlen($str));
+                // Everything validated correctly.
+                $this->assertTrue(true);
             }
         } catch (ValidationException $ex) {
             $this->assertFieldHasError($ex->getValidation(), 'str', $code);
@@ -51,9 +57,11 @@ class StringValidationTest extends AbstractSchemaTest {
             'ab' => ['ab', 'minLength'],
             'abc' => ['abc', ''],
             'abcd' => ['abcd', ''],
-
             'empty 1' => ['', 'missingField', 1],
-            'empty 0' => ['', '', 0]
+            'empty 0' => ['', '', 0],
+            'unicode as bytes success' => ['😱', '', 4],
+            'unicode as unicode fail' => ['😱', 'minLength', 2, Schema::VALIDATE_STRING_LENGTH_AS_UNICODE],
+            'unicode as unicode success' => ['😱', '', 1, Schema::VALIDATE_STRING_LENGTH_AS_UNICODE],
         ];
 
         return $r;
@@ -65,16 +73,18 @@ class StringValidationTest extends AbstractSchemaTest {
      * @param string $str The string to test.
      * @param string $code The expected error code, if any.
      * @param int $maxLength The max length to test.
-     * @param int|null $maxByteLength The max byte length to test.
+     * @param int $flags Flags to set on the schema.
      *
      * @dataProvider provideMaxLengthTests
      */
-    public function testMaxLength($str, string $code = '', int $maxLength = 3, int $maxByteLength = null) {
-        $shorthand = ['maxLength' => $maxLength];
-        if ($maxByteLength) {
-            $shorthand['maxByteLength'] = $maxByteLength;
+    public function testMaxLength($str, string $code = '', int $maxLength = 3, int $flags = null) {
+        $schema = Schema::parse(['str:s?' => [
+            'maxLength' => $maxLength,
+        ]]);
+
+        if ($flags !== null) {
+            $schema->setFlags($flags);
         }
-        $schema = Schema::parse(['str:s?' => $shorthand]);
 
         try {
             $schema->validate(['str' => $str]);
@@ -82,7 +92,8 @@ class StringValidationTest extends AbstractSchemaTest {
             if (!empty($code)) {
                 $this->fail("'$str' shouldn't validate against a max length of $maxLength.");
             } else {
-                $this->assertLessThanOrEqual($maxLength, strlen($str));
+                // Everything validated correctly.
+                $this->assertTrue(true);
             }
         } catch (ValidationException $ex) {
             $this->assertFieldHasError($ex->getValidation(), 'str', $code);
@@ -100,8 +111,9 @@ class StringValidationTest extends AbstractSchemaTest {
             'ab' => ['ab'],
             'abc' => ['abc'],
             'abcd' => ['abcd', 'maxLength'],
-            'multibyte short' => ['😱', '', 4, 4],
-            'multibyte long' => ['😱😱', 'maxByteLength', 4, 4],
+            'long multibyte with unicode length' => ['😱', '', 2, Schema::VALIDATE_STRING_LENGTH_AS_UNICODE],
+            'long multibyte with byte length' => ['😱', 'maxLength', 2],
+            'exact amount multibyte with byte length' => ['😱', '', 4],
         ];
 
         return $r;


### PR DESCRIPTION
Backporting #73 to release/1.x

The README got whacked with autoformatting and it was a bit hairy due to the merge conflicts while backporting. [View without whitespace changes](https://github.com/vanilla/garden-schema/pull/74/files?diff=split&w=1)