### PR TITLE
Upgrade to php 8.1

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1906,6 +1906,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      * @link http://json-schema.org/
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {
         $seen = [$this];
         return $this->jsonSerializeInternal($seen);

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -2081,6 +2081,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @return boolean true on success or false on failure.
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset) {
         return isset($this->schema[$offset]);
     }
@@ -2092,6 +2093,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @return mixed Can return all value types.
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset) {
         return isset($this->schema[$offset]) ? $this->schema[$offset] : null;
     }
@@ -2103,6 +2105,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @param mixed $value The value to set.
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value) {
         $this->schema[$offset] = $value;
     }
@@ -2113,6 +2116,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @param mixed $offset The offset to unset.
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset) {
         unset($this->schema[$offset]);
     }

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -578,6 +578,7 @@ class Validation implements \JsonSerializable {
      * which is a value of any type other than a resource.
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {
         $errors = [];
 

--- a/src/ValidationException.php
+++ b/src/ValidationException.php
@@ -36,6 +36,7 @@ class ValidationException extends \Exception implements \JsonSerializable {
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {
         return $this->validation->jsonSerialize();
     }

--- a/tests/StringValidationTest.php
+++ b/tests/StringValidationTest.php
@@ -194,7 +194,7 @@ class StringValidationTest extends AbstractSchemaTest {
             if (!empty($code)) {
                 $this->fail("'$str' shouldn't validate against a pattern of $pattern.");
             } else {
-                $this->assertRegExp("/{$pattern}/", $str);
+                $this->assertMatchesRegularExpression("/{$pattern}/", $str);
             }
         } catch (ValidationException $ex) {
             $this->assertFieldHasError($ex->getValidation(), 'str', $code);


### PR DESCRIPTION
# Changes
* Add `#[\ReturnTypeWillChange]` to ensure PHP 8.2 support.
* Replace deprecated assertRegExp() with the new and shiny assertMatchesRegularExpression().