### PR TITLE
Fix schema elements type hinting

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -274,7 +274,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
      * @return array Returns an array in the form `[string name, array param, bool required]`.
      * @throws ParseException Throws an exception if the short param is not in the correct format.
      */
-    public function parseShortParam(string $key, array $value = []): array {
+    public function parseShortParam(string $key, $value = []): array {
         $nullable = false;
         $required = true;
         $typeStr = '';

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -780,7 +780,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
     }
 
     /**
-     * Add a custom validator to to validate the schema.
+     * Add a custom validator to validate the schema.
      *
      * @param string $fieldname The name of the field to validate, if any.
      *

--- a/tests/RealWorldTest.php
+++ b/tests/RealWorldTest.php
@@ -129,6 +129,35 @@ class RealWorldTest extends TestCase {
     }
 
     /**
+     * Colons should be allowed in property name short definitions.
+     */
+    public function testColonLongParse() {
+        $sch = Schema::parse([
+            'foo:bar' => [
+                'type' => 'boolean',
+            ],
+        ]);
+
+        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
+    }
+
+    /**
+     * Colons should be allowed in full property name definitions.
+     */
+    public function testColonFullParse() {
+        $sch = Schema::parse([
+            'type' => 'object',
+            'properties' => [
+                'foo:bar' => [
+                    'type' => 'boolean',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
+    }
+
+    /**
      * A nested schema object should have its default value respected.
      */
     public function testNestedDefaultRequired() {

--- a/tests/RealWorldTest.php
+++ b/tests/RealWorldTest.php
@@ -129,35 +129,6 @@ class RealWorldTest extends TestCase {
     }
 
     /**
-     * Colons should be allowed in property name short definitions.
-     */
-    public function testColonLongParse() {
-        $sch = Schema::parse([
-            'foo:bar' => [
-                'type' => 'boolean',
-            ],
-        ]);
-
-        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
-    }
-
-    /**
-     * Colons should be allowed in full property name definitions.
-     */
-    public function testColonFullParse() {
-        $sch = Schema::parse([
-            'type' => 'object',
-            'properties' => [
-                'foo:bar' => [
-                    'type' => 'boolean',
-                ],
-            ],
-        ]);
-
-        $this->assertEquals('boolean', $sch->getField('properties/foo:bar/type'));
-    }
-
-    /**
      * A nested schema object should have its default value respected.
      */
     public function testNestedDefaultRequired() {


### PR DESCRIPTION
Changes summary

- Supported field:type? syntax for optional fields (legacy style).
- Normalized timestamp and datetime types to standard JSON Schema equivalents:
  - timestamp → integer with format: timestamp
  - datetime → string with format: date-time