### PR TITLE
Add compatibility for type as array

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -298,6 +298,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
         elseif (substr($key, -1) === '?') {
             $name = substr($key, 0, -1);
             $typeStr = $value['type'] ?? '';
+            $typeStr = (is_array($typeStr) ? implode('|', $typeStr) : $typeStr);
             $required = false;
         }
 


### PR DESCRIPTION
RangeExpression's createSchema()(amongst likely others) uses `type` as an array of values (["string", "integer", "array"]) instead of a string. This PR addresses this issue.