### PR TITLE
Restore validation messages

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1327,7 +1327,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
                 if ($exclusive) {
                     $field->addError('maximum', ['messageCode' => 'The value must be less than {maximum}.', 'maximum' => $maximum]);
                 } else {
-                    $field->addError('maximum', ['messageCode' => 'The value must be less than or equal to {maximum}.', 'maximum' => $maximum]);
+                    $field->addError('maximum', ['messageCode' => '{field} is greater than {maximum}.', 'maximum' => $maximum]);
                 }
             }
         }
@@ -1403,7 +1403,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
             $field->addError(
                 'maxLength',
                 [
-                    'messageCode' => 'The value is {overflow} {overflow,plural,character,characters} too long.',
+                    'messageCode' => '{field} is {overflow} {overflow,plural,character,characters} too long.',
                     'maxLength' => $maxLength,
                     'overflow' => $mbStrLen - $maxLength,
                 ]
@@ -1418,7 +1418,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
                 $field->addError(
                     'maxByteLength',
                     [
-                        'messageCode' => 'The value is {overflow} {overflow,plural,byte,bytes} too long.',
+                        'messageCode' => '{field} is {overflow} {overflow,plural,byte,bytes} too long.',
                         'maxLength' => $maxLength,
                         'overflow' => $byteStrLen - $maxByteLength,
                     ]
@@ -1894,7 +1894,7 @@ class Schema implements \JsonSerializable, \ArrayAccess {
             $field->addError(
                 'enum',
                 [
-                    'messageCode' => 'The value must be one of: {enum}.',
+                    'messageCode' => '{field} must be one of: {enum}.',
                     'enum' => $enum,
                 ]
             );

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -212,20 +212,33 @@ class Validation implements \JsonSerializable {
      * @return string Formatted error message string.
      */
     private function formatErrorList(string $field, array $errors): string {
+        // Determine if this is an unnamed/general error (not tied to a specific field).
+        $isUnnamed = empty($field);
+
+        // Resolve and format the actual error messages for the field.
         $messages = $this->errorMessages($field, $errors);
 
+        // No messages? Return an empty string.
         if (empty($messages)) {
             return '';
         }
 
-        if ($field === '') {
-            return implode(' ', $messages);
+        // Format the field name (if named).
+        $fieldLabel = $isUnnamed ? '' : $this->formatFieldName($field);
+        $separator = " ";
+
+        // For unnamed fields, just return the concatenated messages.
+        if ($isUnnamed) {
+            return implode($separator, $messages);
         }
 
-        $fieldLabel = $this->formatFieldName($field);
-        $formattedMessages = implode(' ', $messages);
+        // If there's only one message, omit the label prefix (by design).
+        if (count($messages) === 1) {
+            return sprintf('%s', $messages[0]);
+        }
 
-        return sprintf('%s: %s', $fieldLabel, $formattedMessages);
+        // Otherwise, include the field label followed by all messages.
+        return sprintf('%s:%s%s', $fieldLabel, $separator, implode($separator, $messages));
     }
 
     /**

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -160,7 +160,7 @@ class Validation implements \JsonSerializable {
             $paras[] = $this->formatErrorList($field, $errors);
         }
 
-        $result = implode("\n\n", $paras);
+        $result = implode(" ", $paras);
         return $result;
     }
 
@@ -211,23 +211,26 @@ class Validation implements \JsonSerializable {
      * @param array $errors The field's errors.
      * @return string Returns the error messages, translated and formatted.
      */
-    private function formatErrorList(string $field, array $errors) {
-        if (empty($field)) {
-            $fieldName = '';
-            $colon = '%s%s';
-            $sep = "\n";
-        } else {
-            $fieldName = $this->formatFieldName($field);
-            $colon = $this->translate('%s');
-            $sep = "\n  ";
-            if (count($errors) > 1) {
-                $colon = rtrim(sprintf($colon, '%s', "")).$sep.'%s';
-            }
+    private function formatErrorList(string $field, array $errors): string {
+        $isUnnamed = empty($field);
+        $messages = $this->errorMessages($field, $errors);
+
+        if (empty($messages)) {
+            return '';
         }
 
-        $messages = $this->errorMessages($field, $errors);
-        $result = sprintf($colon, implode($sep, $messages));
-        return $result;
+        $fieldLabel = $isUnnamed ? '' : $this->formatFieldName($field);
+        $separator = " ";
+
+        if ($isUnnamed) {
+            return implode($separator, $messages);
+        }
+
+        if (count($messages) === 1) {
+            return sprintf('%s: %s', $fieldLabel, $messages[0]);
+        }
+
+        return sprintf('%s:%s%s', $fieldLabel, $separator, implode($separator, $messages));
     }
 
     /**

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -218,7 +218,7 @@ class Validation implements \JsonSerializable {
             $sep = "\n";
         } else {
             $fieldName = $this->formatFieldName($field);
-            $colon = $this->translate('%s: %s');
+            $colon = $this->translate('%s');
             $sep = "\n  ";
             if (count($errors) > 1) {
                 $colon = rtrim(sprintf($colon, '%s', "")).$sep.'%s';
@@ -226,7 +226,7 @@ class Validation implements \JsonSerializable {
         }
 
         $messages = $this->errorMessages($field, $errors);
-        $result = sprintf($colon, $fieldName, implode($sep, $messages));
+        $result = sprintf($colon, implode($sep, $messages));
         return $result;
     }
 

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -227,7 +227,7 @@ class Validation implements \JsonSerializable {
         }
 
         if (count($messages) === 1) {
-            return sprintf('%s: %s', $fieldLabel, $messages[0]);
+            return sprintf(/*'%s: '*/'%s', /*$fieldLabel, */$messages[0]);
         }
 
         return sprintf('%s:%s%s', $fieldLabel, $separator, implode($separator, $messages));

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -205,32 +205,27 @@ class Validation implements \JsonSerializable {
     }
 
     /**
-     * Format a field's errors.
+     * Format a field's error messages into a single string.
      *
-     * @param string $field The field name.
-     * @param array $errors The field's errors.
-     * @return string Returns the error messages, translated and formatted.
+     * @param string $field The field name. If empty, messages are treated as global.
+     * @param array $errors The list of errors for the field.
+     * @return string Formatted error message string.
      */
     private function formatErrorList(string $field, array $errors): string {
-        $isUnnamed = empty($field);
         $messages = $this->errorMessages($field, $errors);
 
         if (empty($messages)) {
             return '';
         }
 
-        $fieldLabel = $isUnnamed ? '' : $this->formatFieldName($field);
-        $separator = " ";
-
-        if ($isUnnamed) {
-            return implode($separator, $messages);
+        if ($field === '') {
+            return implode(' ', $messages);
         }
 
-        if (count($messages) === 1) {
-            return sprintf(/*'%s: '*/'%s', /*$fieldLabel, */$messages[0]);
-        }
+        $fieldLabel = $this->formatFieldName($field);
+        $formattedMessages = implode(' ', $messages);
 
-        return sprintf('%s:%s%s', $fieldLabel, $separator, implode($separator, $messages));
+        return sprintf('%s: %s', $fieldLabel, $formattedMessages);
     }
 
     /**

--- a/src/ValidationField.php
+++ b/src/ValidationField.php
@@ -86,7 +86,7 @@ class ValidationField {
             [
                 'type' => $type,
                 'value' => is_scalar($value) ? $value : null,
-                'messageCode' => is_scalar($value) ? "{value} is not a valid $type." : "The value is not a valid $type."
+                'messageCode' => is_scalar($value) ? "{value} is not a valid $type." : "{field} is not a valid $type."
             ]
         );
 

--- a/tests/DiscriminatorTest.php
+++ b/tests/DiscriminatorTest.php
@@ -158,7 +158,7 @@ class DiscriminatorTest extends TestCase {
      */
     public function testDiscriminatorTypeNotFound() {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("type: \"Foo\" is not a valid option.");
+        $this->expectExceptionMessage("\"Foo\" is not a valid option.");
         $valid = $this->schema->validate(['type' => 'Foo']);
     }
 
@@ -167,7 +167,7 @@ class DiscriminatorTest extends TestCase {
      */
     public function testDiscriminatorCyclicalRef() {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("type: \"Pet\" is not a valid option.");
+        $this->expectExceptionMessage("\"Pet\" is not a valid option.");
         $valid = $this->schema->validate(['type' => 'Pet']);
     }
 
@@ -185,7 +185,7 @@ class DiscriminatorTest extends TestCase {
      */
     public function testDiscriminatorInfiniteRecursion() {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("type: \"Pet\" is not a valid option.");
+        $this->expectExceptionMessage("\"Pet\" is not a valid option.");
         $valid = $this->schema->validate(['type' => 'Bird', 'subtype' => 'Pet']);
     }
 
@@ -194,7 +194,7 @@ class DiscriminatorTest extends TestCase {
      */
     public function testDiscriminatorTypeError() {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("type: The value is not a valid string.");
+        $this->expectExceptionMessage("The value is not a valid string.");
         $valid = $this->schema->validate(['type' => ['hey!!!']]);
     }
 
@@ -203,7 +203,7 @@ class DiscriminatorTest extends TestCase {
      */
     public function testEmptyDiscriminator() {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("type: type is required.");
+        $this->expectExceptionMessage("type is required.");
         $valid = $this->schema->validate([]);
     }
 
@@ -229,7 +229,7 @@ class DiscriminatorTest extends TestCase {
      */
     public function testOneOfRef() {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('subtype: "Dog" is not a valid option.');
+        $this->expectExceptionMessage('"Dog" is not a valid option.');
         $valid = $this->schema->validate(['type' => 'Bird', 'subtype' => 'Dog']);
     }
 }

--- a/tests/DiscriminatorTest.php
+++ b/tests/DiscriminatorTest.php
@@ -163,7 +163,7 @@ class DiscriminatorTest extends TestCase {
     }
 
     /**
-     * A discriminators should fail if the discriminate to themselves.
+     * A discriminator should fail if it refers to its own schema, creating a circular reference.
      */
     public function testDiscriminatorCyclicalRef() {
         $this->expectException(ValidationException::class);

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -101,7 +101,7 @@ class NestedSchemaTest extends AbstractSchemaTest {
         } catch (ValidationException $ex) {
             $validation = $ex->getValidation();
             $this->assertFalse($validation->isValidField('arr/2'));
-            $this->assertEquals('arr/2 must be less than 2.', $validation->getMessage());
+            $this->assertEquals('arr/2: arr/2 must be less than 2.', $validation->getMessage());
         }
     }
 

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -101,7 +101,7 @@ class NestedSchemaTest extends AbstractSchemaTest {
         } catch (ValidationException $ex) {
             $validation = $ex->getValidation();
             $this->assertFalse($validation->isValidField('arr/2'));
-            $this->assertEquals('arr/2: arr/2 must be less than 2.', $validation->getMessage());
+            $this->assertEquals('arr/2 must be less than 2.', $validation->getMessage());
         }
     }
 

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -354,7 +354,7 @@ class NestedSchemaTest extends AbstractSchemaTest {
             $errors = $ex->getValidation()->getErrors();
             $this->assertCount(2, $errors);
             $this->assertEquals('name is required.', $errors[0]['message']);
-            $this->assertEquals('The value is not a valid string.', $errors[1]['message']);
+            $this->assertEquals('1/name is not a valid string.', $errors[1]['message']);
         }
     }
 

--- a/tests/ValidationClassTest.php
+++ b/tests/ValidationClassTest.php
@@ -45,7 +45,7 @@ class ValidationClassTest extends TestCase {
         $vld = new Validation();
         $vld->addError('foo', 'The {field}!');
 
-        $this->assertSame('foo: The foo!', $vld->getMessage());
+        $this->assertSame('The foo!', $vld->getMessage());
     }
 
     /**
@@ -100,7 +100,7 @@ class ValidationClassTest extends TestCase {
 
         $vld->addError('it', 'Keeping {field} {number}', ['number' => 100]);
 
-        $this->assertSame('!it: !Keeping !it 100', $vld->getFullMessage());
+        $this->assertSame('!Keeping !it 100', $vld->getFullMessage());
     }
 
     /**

--- a/tests/ValidationClassTest.php
+++ b/tests/ValidationClassTest.php
@@ -100,7 +100,7 @@ class ValidationClassTest extends TestCase {
 
         $vld->addError('it', 'Keeping {field} {number}', ['number' => 100]);
 
-        $this->assertSame('!!it: !Keeping !it 100', $vld->getFullMessage());
+        $this->assertSame('!it: !Keeping !it 100', $vld->getFullMessage());
     }
 
     /**

--- a/tests/ValidationClassTest.php
+++ b/tests/ValidationClassTest.php
@@ -45,7 +45,7 @@ class ValidationClassTest extends TestCase {
         $vld = new Validation();
         $vld->addError('foo', 'The {field}!');
 
-        $this->assertSame('The foo!', $vld->getMessage());
+        $this->assertSame('foo: The foo!', $vld->getMessage());
     }
 
     /**
@@ -100,7 +100,7 @@ class ValidationClassTest extends TestCase {
 
         $vld->addError('it', 'Keeping {field} {number}', ['number' => 100]);
 
-        $this->assertSame('!Keeping !it 100', $vld->getFullMessage());
+        $this->assertSame('!it: !Keeping !it 100', $vld->getFullMessage());
     }
 
     /**

--- a/tests/ValidationErrorMessageTest.php
+++ b/tests/ValidationErrorMessageTest.php
@@ -13,7 +13,7 @@ use Garden\Schema\Validation;
 /**
  * Tests for the `Validation` class' error message formatting.
  */
-class ValidationErrorMesageTest extends AbstractSchemaTest {
+class ValidationErrorMessageTest extends AbstractSchemaTest {
 
     /**
      * An empty validation object should return no error message.
@@ -77,7 +77,7 @@ class ValidationErrorMesageTest extends AbstractSchemaTest {
     public function testTwoFieldlessErrors() {
         $vld = $this->createErrors('', 2);
 
-        $this->assertSame("!error 1\n!error 2", $vld->getFullMessage());
+        $this->assertSame("!error 1 !error 2", $vld->getFullMessage());
     }
 
     /**
@@ -85,7 +85,7 @@ class ValidationErrorMesageTest extends AbstractSchemaTest {
      */
     public function testOneFieldError() {
         $vld = $this->createErrors('', 0, 1);
-        $this->assertSame('![Field 1]: !error 1', $vld->getFullMessage());
+        $this->assertSame('[Field 1]: !error 1', $vld->getFullMessage());
     }
 
     /**
@@ -93,7 +93,7 @@ class ValidationErrorMesageTest extends AbstractSchemaTest {
      */
     public function testTwoFieldErrors() {
         $vld = $this->createErrors('', 0, 2);
-        $this->assertSame("![Field 1]:\n  !error 1\n  !error 2", $vld->getFullMessage());
+        $this->assertSame("[Field 1]: !error 1 !error 2", $vld->getFullMessage());
     }
 
     /**
@@ -102,7 +102,7 @@ class ValidationErrorMesageTest extends AbstractSchemaTest {
     public function testMainAndFieldError() {
         $vld = $this->createErrors('Failed', 0, 1);
 
-        $this->assertSame("!Failed\n\n![Field 1]: !error 1", $vld->getFullMessage());
+        $this->assertSame("!Failed [Field 1]: !error 1", $vld->getFullMessage());
     }
 
     /**
@@ -114,7 +114,7 @@ class ValidationErrorMesageTest extends AbstractSchemaTest {
         $vld->addError('foo', 'bar');
         $vld->addError('', 'baz');
 
-        $this->assertSame("!baz\n\n![foo]: !bar", $vld->getFullMessage());
+        $this->assertSame("!baz [foo]: !bar", $vld->getFullMessage());
     }
 
     /**

--- a/tests/ValidationErrorMessageTest.php
+++ b/tests/ValidationErrorMessageTest.php
@@ -85,7 +85,7 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
      */
     public function testOneFieldError() {
         $vld = $this->createErrors('', 0, 1);
-        $this->assertSame('!error 1', $vld->getFullMessage());
+        $this->assertSame('[Field 1]: !error 1', $vld->getFullMessage());
     }
 
     /**
@@ -102,7 +102,7 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
     public function testMainAndFieldError() {
         $vld = $this->createErrors('Failed', 0, 1);
 
-        $this->assertSame("!Failed !error 1", $vld->getFullMessage());
+        $this->assertSame("!Failed [Field 1]: !error 1", $vld->getFullMessage());
     }
 
     /**
@@ -114,7 +114,7 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
         $vld->addError('foo', 'bar');
         $vld->addError('', 'baz');
 
-        $this->assertSame("!baz !bar", $vld->getFullMessage());
+        $this->assertSame("!baz [foo]: !bar", $vld->getFullMessage());
     }
 
     /**

--- a/tests/ValidationErrorMessageTest.php
+++ b/tests/ValidationErrorMessageTest.php
@@ -85,7 +85,7 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
      */
     public function testOneFieldError() {
         $vld = $this->createErrors('', 0, 1);
-        $this->assertSame('[Field 1]: !error 1', $vld->getFullMessage());
+        $this->assertSame('!error 1', $vld->getFullMessage());
     }
 
     /**
@@ -102,7 +102,7 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
     public function testMainAndFieldError() {
         $vld = $this->createErrors('Failed', 0, 1);
 
-        $this->assertSame("!Failed [Field 1]: !error 1", $vld->getFullMessage());
+        $this->assertSame("!Failed !error 1", $vld->getFullMessage());
     }
 
     /**
@@ -114,7 +114,7 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
         $vld->addError('foo', 'bar');
         $vld->addError('', 'baz');
 
-        $this->assertSame("!baz [foo]: !bar", $vld->getFullMessage());
+        $this->assertSame("!baz !bar", $vld->getFullMessage());
     }
 
     /**


### PR DESCRIPTION
This PR restores validations & error messages so they are much closer to the ones currently used on the Vanilla platform.
This is a second attempt at [this](https://github.com/vanilla/garden-schema/pull/91) as the previous iteration was getting quite messy.
Related issue: https://higherlogic.atlassian.net/browse/VNLA-8757