### PR TITLE
Fix messages for garden-hydrate's tests

### DIFF
--- a/src/ValidationField.php
+++ b/src/ValidationField.php
@@ -86,7 +86,7 @@ class ValidationField {
             [
                 'type' => $type,
                 'value' => is_scalar($value) ? $value : null,
-                'messageCode' => is_scalar($value) ? "{value} is not a valid $type." : "{field} is not a valid $type."
+                'messageCode' => is_scalar($value) ? "{field}: {value} is not a valid $type." : "{field}: The value is not a valid $type."
             ]
         );
 

--- a/tests/BackwardsCompatibilityTest.php
+++ b/tests/BackwardsCompatibilityTest.php
@@ -141,7 +141,7 @@ class BackwardsCompatibilityTest extends AbstractSchemaTest {
         try {
             $schema->validate('aaa');
         } catch (ValidationException $ex) {
-            $this->assertSame('!"aaa" is not a valid integer.', $ex->getMessage());
+            $this->assertSame('![value]: "aaa" is not a valid integer.', $ex->getMessage());
         }
 
         $validation = new TestValidation();
@@ -150,14 +150,14 @@ class BackwardsCompatibilityTest extends AbstractSchemaTest {
         try {
             $schema->validate('aaa');
         } catch (ValidationException $ex) {
-            $this->assertSame('!"aaa" is not a valid integer.', $ex->getMessage());
+            $this->assertSame('![value]: "aaa" is not a valid integer.', $ex->getMessage());
         }
 
         $validation->setTranslateFieldNames(true);
         try {
             $schema->validate('aaa');
         } catch (ValidationException $ex) {
-            $this->assertSame('!!"aaa" is not a valid integer.', $ex->getMessage());
+            $this->assertSame('!!value: !"aaa" is not a valid integer.', $ex->getMessage());
         }
     }
 

--- a/tests/BasicSchemaTest.php
+++ b/tests/BasicSchemaTest.php
@@ -435,7 +435,7 @@ class BasicSchemaTest extends AbstractSchemaTest {
         try {
             $schema->validate('aaa');
         } catch (ValidationException $ex) {
-            $this->assertSame('!"aaa" is not a valid integer.', $ex->getMessage());
+            $this->assertSame('![value]: "aaa" is not a valid integer.', $ex->getMessage());
         }
     }
 

--- a/tests/NestedSchemaTest.php
+++ b/tests/NestedSchemaTest.php
@@ -354,7 +354,7 @@ class NestedSchemaTest extends AbstractSchemaTest {
             $errors = $ex->getValidation()->getErrors();
             $this->assertCount(2, $errors);
             $this->assertEquals('0/name is required.', $errors[0]['message']);
-            $this->assertEquals('1/name is not a valid string.', $errors[1]['message']);
+            $this->assertEquals('1/name: The value is not a valid string.', $errors[1]['message']);
         }
     }
 

--- a/tests/ObjectValidationTest.php
+++ b/tests/ObjectValidationTest.php
@@ -107,7 +107,7 @@ class ObjectValidationTest extends AbstractSchemaTest {
             $valid = $sch->validate(['~/' => 123.4]);
             $this->fail("There should be a validation exception.");
         } catch (ValidationException $ex) {
-            $this->assertSame('123.4 is not a valid integer.', $ex->getValidation()->getConcatMessage('~0~1'));
+            $this->assertSame('value: 123.4 is not a valid integer.', $ex->getValidation()->getConcatMessage('~0~1'));
         }
     }
 }


### PR DESCRIPTION
Some of the newer messages were incompatible with a few checks on `garden-hydrate`'s test suite.
This PR unblocks CI on this `garden-hydrate` PR: https://github.com/vanilla/garden-hydrate/pull/17
I also checked with compatibility with the full Vanilla product's test suite.