### PR TITLE
Fix compatibility with previous main release // VNLA-9506

### DIFF
--- a/open-api.json
+++ b/open-api.json
@@ -44,31 +44,42 @@
 					"errors": {
 						"title": "Field Errors",
 						"description": "A mapping of field references to errors.",
-						"type": "object",
-						"additionalProperties": {
-							"type": "array",
-							"items": {
-								"type": "object",
-								"properties": {
-									"message": {
-										"description": "A human-readable error message.",
-										"type": "string"
-									},
-									"error": {
-										"description": "A string code for the specific validation error meant for consumption by code.",
-										"type": "string"
-									},
-									"code": {
-										"description": "An HTTP-style error code for the error.",
-										"type": "integer"
-									}
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"message": {
+									"description": "A human-readable error message.",
+									"type": "string"
 								},
-								"required": ["message", "error"],
-								"example": {
-									"message": "The value should be at least 10 characters long.",
-									"error": "minLength",
-									"code": 400
+								"error": {
+									"description": "A string code for the specific validation error meant for consumption by code.",
+									"type": "string"
+								},
+								"code": {
+									"description": "An HTTP-style error code for the error.",
+									"type": "integer"
+								},
+								"status": {
+									"description": "An HTTP-style error code for the error.",
+									"type": "integer"
+								},
+								"field": {
+									"description": "Field the error applies to",
+									"type": "string"
 								}
+							},
+							"required": [
+								"message",
+								"error",
+								"status",
+								"field"
+							],
+							"example": {
+								"message": "The value should be at least 10 characters long.",
+								"error": "minLength",
+								"field": "myField",
+								"status": 400
 							}
 						}
 					}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="tests/phpunit.php"
-        >
-    <php>
-        <ini name="intl.default_locale" value="en"/>
-        <ini name="intl.error_level" value="0"/>
-        <ini name="memory_limit" value="-1"/>
-        <ini name="date.timezone" value="America/Montreal"/>
-    </php>
-
-    <testsuites>
-        <testsuite name="Garden Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix=".php">vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">vendor</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="intl.default_locale" value="en"/>
+    <ini name="intl.error_level" value="0"/>
+    <ini name="memory_limit" value="-1"/>
+    <ini name="date.timezone" value="America/Montreal"/>
+  </php>
+  <testsuites>
+    <testsuite name="Garden Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -437,7 +437,7 @@ class Validation implements \JsonSerializable {
     private function pluckError(array $error) {
         $row = array_intersect_key(
             $error,
-            ['field' => 1, 'error' => 1, 'code' => 1]
+            ['field' => 1, 'error' => 1, 'code' => 1, 'status' => 1]
         );
 
         $row['message'] = $this->formatErrorMessage($error);
@@ -593,10 +593,7 @@ class Validation implements \JsonSerializable {
         $errors = [];
 
         foreach ($this->getRawErrors() as $field => $error) {
-            $errors[$field][] = array_intersect_key(
-                $this->pluckError($error + ['field' => $field]),
-                ['error' => 1, 'message' => 1, 'code' => 1]
-            );
+            $errors[] = $this->pluckError($error + ['field' => $field, 'status' => 400]);
         }
 
         $result = [

--- a/tests/ValidationErrorMessageTest.php
+++ b/tests/ValidationErrorMessageTest.php
@@ -141,9 +141,14 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
     public function testOneFieldlessErrorJSON() {
         $vld = $this->createErrors('', 1);
         $json = $vld->jsonSerialize();
-        $this->assertEquals(['message' => '!Validation failed.', 'code' => 400, 'errors' => [
-            '' => [['error' => 'error 1', 'message' => '!error 1']]
-        ]], $json);
+        $this->assertEquals(
+            [
+                'message' => '!Validation failed.',
+                'code' => 400,
+                'errors' => [
+                    ['error' => 'error 1', 'message' => '!error 1', 'status' => 400, 'field' => '']
+                ]
+        ], $json);
     }
 
     /**
@@ -154,17 +159,11 @@ class ValidationErrorMessageTest extends AbstractSchemaTest {
         $vld->addError('Field X', 'error 1', ['code' => 433, 'messageCode' => 'foo']);
         $json = $vld->jsonSerialize();
         $this->assertEquals(['message' => '!Foo', 'code' => 433, 'errors' => [
-            'Field 1' => [
-                ['error' => 'error 1', 'message' => '!error 1'],
-                ['error' => 'error 2', 'message' => '!error 2']
-            ],
-            'Field 2' => [
-                ['error' => 'error 1', 'message' => '!error 1'],
-                ['error' => 'error 2', 'message' => '!error 2']
-            ],
-            'Field X' => [
-                ['error' => 'error 1', 'code' => 433, 'message' => '!foo'],
-            ],
+            ['error' => 'error 1', 'message' => '!error 1', 'status' => 400, 'field' => 'Field 1'],
+            ['error' => 'error 2', 'message' => '!error 2', 'status' => 400, 'field' => 'Field 1'],
+            ['error' => 'error 1', 'message' => '!error 1', 'status' => 400, 'field' => 'Field 2'],
+            ['error' => 'error 2', 'message' => '!error 2', 'status' => 400, 'field' => 'Field 2'],
+            ['error' => 'error 1', 'code' => 433, 'message' => '!foo', 'status' => 400, 'field' => 'Field X'],
         ]], $json);
     }
 


### PR DESCRIPTION
## Garden-Schema Changes Summary

### Overview

Restructured the validation error output format to provide a more consistent, standardized error structure that improves API consistency and frontend error handling.

#### Key Changes
1. Error Structure Transformation
Before: Errors were organized by field name in a nested object structure
After: Errors are now returned as a flat array with explicit field information embedded in each error object
2. Enhanced Error Object Properties
Added status field: Each error now includes the HTTP status code
Added field field: Each error explicitly includes the field name it applies to
Standardized structure: All errors now have consistent, predictable properties
3. API Documentation Updates
OpenAPI specification: Updated to reflect the new array-based error structure
Required fields: Now includes message, error, status, and field for each error
Better examples: Provides clearer documentation of the expected error format