### PR TITLE
Update entity property sorting to be based off of class inheritence

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -85,7 +85,7 @@ abstract class Entity implements EntityInterface, \ArrayAccess, \JsonSerializabl
     protected static function buildSchema(string $class, \BackedEnum $variant): Schema {
         $reflection = new ReflectionClass($class);
         // Get all properties, not just public - non-public properties with PropertySchema will be schema-only
-        $properties = $reflection->getProperties();
+        $properties = EntityReflectionUtils::getSortedProperties($reflection, null);
         $properties = self::sortPropertiesBySchemaOrder($properties);
         $schemaProperties = [];
         $required = [];

--- a/src/EntityReflectionUtils.php
+++ b/src/EntityReflectionUtils.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2026 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Schema;
+
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * Reflection utility helpers for entity processing.
+ */
+class EntityReflectionUtils {
+
+    /**
+     * Get reflection properties sorted by inheritance declaration order.
+     *
+     * The returned properties mirror ReflectionClass::getProperties($filters), but are
+     * re-ordered so properties introduced by base classes come first.
+     *
+     * For redeclared properties, ordering is based on the first class in the inheritance
+     * chain that introduced that property name.
+     *
+     * @param ReflectionClass $reflectedClass
+     * @param int|null $filters ReflectionProperty filter mask.
+     * @return ReflectionProperty[]
+     */
+    public static function getSortedProperties(ReflectionClass $reflectedClass, ?int $filters): array {
+        $properties = $filters === null
+            ? $reflectedClass->getProperties()
+            : $reflectedClass->getProperties($filters);
+
+        $inheritanceChain = [];
+        for ($cursor = $reflectedClass; $cursor !== false; $cursor = $cursor->getParentClass()) {
+            $inheritanceChain[] = $cursor;
+        }
+        $inheritanceChain = array_reverse($inheritanceChain);
+
+        $classDepth = [];
+        $propertyIntroductionOrder = [];
+        $order = 0;
+
+        foreach ($inheritanceChain as $depth => $class) {
+            $classDepth[$class->getName()] = $depth;
+            $classProperties = $filters === null
+                ? $class->getProperties()
+                : $class->getProperties($filters);
+
+            foreach ($classProperties as $property) {
+                if ($property->getDeclaringClass()->getName() !== $class->getName()) {
+                    continue;
+                }
+                $propertyName = $property->getName();
+                if (!array_key_exists($propertyName, $propertyIntroductionOrder)) {
+                    $propertyIntroductionOrder[$propertyName] = $order++;
+                }
+            }
+        }
+
+        $sortableProperties = [];
+        foreach ($properties as $index => $property) {
+            $declaringClassName = $property->getDeclaringClass()->getName();
+            $sortableProperties[] = [
+                "property" => $property,
+                "firstSeenOrder" => $propertyIntroductionOrder[$property->getName()] ?? PHP_INT_MAX,
+                "declaringClassDepth" => $classDepth[$declaringClassName] ?? PHP_INT_MAX,
+                "originalIndex" => $index,
+            ];
+        }
+
+        usort($sortableProperties, function (array $a, array $b): int {
+            $comparison = $a["firstSeenOrder"] <=> $b["firstSeenOrder"];
+            if ($comparison !== 0) {
+                return $comparison;
+            }
+
+            $comparison = $a["declaringClassDepth"] <=> $b["declaringClassDepth"];
+            if ($comparison !== 0) {
+                return $comparison;
+            }
+
+            return $a["originalIndex"] <=> $b["originalIndex"];
+        });
+
+        return array_map(fn(array $item): ReflectionProperty => $item["property"], $sortableProperties);
+    }
+}

--- a/tests/EntityReflectionUtilsTest.php
+++ b/tests/EntityReflectionUtilsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Garden\Schema\Tests;
+
+use Garden\Schema\EntityReflectionUtils;
+use Garden\Schema\Tests\Fixtures\ReflectionUtilsChildClass;
+use Garden\Schema\Tests\Fixtures\ReflectionUtilsSchemaChildEntity;
+use Garden\Schema\Tests\Fixtures\ReflectionUtilsSecondClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * Tests for EntityReflectionUtils.
+ */
+class EntityReflectionUtilsTest extends TestCase {
+    /**
+     * Properties are sorted so inheritance introduces names first, even when redeclared later.
+     */
+    public function testGetSortedPropertiesSortsByInheritanceChainWithRedeclaredProperty(): void {
+        $reflectedClass = new ReflectionClass(ReflectionUtilsChildClass::class);
+
+        $properties = EntityReflectionUtils::getSortedProperties($reflectedClass, null);
+        $names = array_map(fn(ReflectionProperty $property) => $property->getName(), $properties);
+
+        $this->assertSame(
+            ["baseClassProp", "baseProtectedProp", "secondClassProp", "secondProtectedProp", "thirdClassProp"],
+            $names,
+        );
+    }
+
+    /**
+     * The utility applies the same reflection filters as ReflectionClass::getProperties().
+     */
+    public function testGetSortedPropertiesRespectsFilters(): void {
+        $reflectedClass = new ReflectionClass(ReflectionUtilsChildClass::class);
+
+        $properties = EntityReflectionUtils::getSortedProperties($reflectedClass, ReflectionProperty::IS_PUBLIC);
+        $names = array_map(fn(ReflectionProperty $property) => $property->getName(), $properties);
+
+        $this->assertSame(["baseClassProp", "secondClassProp", "thirdClassProp"], $names);
+    }
+
+    /**
+     * Protected property sorting is also parent-first.
+     */
+    public function testGetSortedPropertiesWithProtectedFilter(): void {
+        $reflectedClass = new ReflectionClass(ReflectionUtilsSecondClass::class);
+
+        $properties = EntityReflectionUtils::getSortedProperties($reflectedClass, ReflectionProperty::IS_PROTECTED);
+        $names = array_map(fn(ReflectionProperty $property) => $property->getName(), $properties);
+
+        $this->assertSame(["baseProtectedProp", "secondProtectedProp"], $names);
+    }
+
+    /**
+     * Entity schema generation starts from parent-first ordering before applying SchemaOrder.
+     */
+    public function testEntityBuildSchemaUsesInheritanceOrderingBeforeSchemaOrder(): void {
+        $schema = ReflectionUtilsSchemaChildEntity::getSchema();
+        $propertyNames = array_keys($schema->getSchemaArray()["properties"]);
+
+        $this->assertSame(["schemaOrdered", "parentA", "parentB", "childA"], $propertyNames);
+    }
+}

--- a/tests/Fixtures/ReflectionUtilsBaseClass.php
+++ b/tests/Fixtures/ReflectionUtilsBaseClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Garden\Schema\Tests\Fixtures;
+
+class ReflectionUtilsBaseClass {
+    public string $baseClassProp;
+    protected string $baseProtectedProp;
+}

--- a/tests/Fixtures/ReflectionUtilsChildClass.php
+++ b/tests/Fixtures/ReflectionUtilsChildClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Garden\Schema\Tests\Fixtures;
+
+class ReflectionUtilsChildClass extends ReflectionUtilsSecondClass {
+    public string $baseClassProp;
+    public string $thirdClassProp;
+}

--- a/tests/Fixtures/ReflectionUtilsSchemaChildEntity.php
+++ b/tests/Fixtures/ReflectionUtilsSchemaChildEntity.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Garden\Schema\Tests\Fixtures;
+
+use Garden\Schema\SchemaOrder;
+
+class ReflectionUtilsSchemaChildEntity extends ReflectionUtilsSchemaParentEntity {
+    public string $childA;
+
+    #[SchemaOrder(1)]
+    public string $schemaOrdered;
+}

--- a/tests/Fixtures/ReflectionUtilsSchemaParentEntity.php
+++ b/tests/Fixtures/ReflectionUtilsSchemaParentEntity.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Garden\Schema\Tests\Fixtures;
+
+use Garden\Schema\Entity;
+
+class ReflectionUtilsSchemaParentEntity extends Entity {
+    public string $parentA;
+    public string $parentB;
+}

--- a/tests/Fixtures/ReflectionUtilsSecondClass.php
+++ b/tests/Fixtures/ReflectionUtilsSecondClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Garden\Schema\Tests\Fixtures;
+
+class ReflectionUtilsSecondClass extends ReflectionUtilsBaseClass {
+    public string $secondClassProp;
+    protected string $secondProtectedProp;
+}


### PR DESCRIPTION
This PR updates sorting of properties in the `Entity::buildSchema()` to respect class inheritence.

This helps keep consistent sorting for authenticator schemas (and their forms) and also helps with API output by putting common/baseclass fields before subtype specific fields.